### PR TITLE
Added --simple option to only display the final result

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import "github.com/gesquive/fast-cli/fast"
 import "github.com/gesquive/fast-cli/format"
 import "github.com/gesquive/fast-cli/meters"
 
-var version = "v0.2.8"
+var version = "v0.2.9"
 var dirty = ""
 var displayVersion string
 


### PR DESCRIPTION
I want to use fast-cli as part of a nagios service check. It only needs the resulting speed and nothing else.  The --simple option will not print any progress. If --simple is not specified, the output is the same. I upped the version to 0.2.9 as part of this patch.