### PR TITLE
Process error returned by getPage()

### DIFF
--- a/fast/fast-api.go
+++ b/fast/fast-api.go
@@ -1,11 +1,14 @@
 package fast
 
-import "fmt"
-import "bytes"
-import "net/http"
-import "io"
-import "regexp"
-import "github.com/gesquive/cli"
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+
+	"github.com/gesquive/cli"
+)
 
 // UseHTTPS sets if HTTPS is used
 var UseHTTPS = true
@@ -53,7 +56,10 @@ func getFastToken() (token string) {
 	if !UseHTTPS {
 		baseURL = "http://fast.com"
 	}
-	fastBody, _ := getPage(baseURL)
+	fastBody, err := getPage(baseURL)
+	if err != nil {
+		cli.Fatalln(err)
+	}
 
 	// Extract the app script url
 	re := regexp.MustCompile("app-.*\\.js")


### PR DESCRIPTION
I ran into the following error when trying to run the compiled binary on OpenWRT

```
$ ./fast-cli
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/gesquive/fast-cli/fast.getFastToken(0x467810, 0x3)
        /home/mbukowski/go/src/github.com/gesquive/fast-cli/fast/fast-api.go:62 +0x408
github.com/gesquive/fast-cli/fast.GetDlUrls(0x0, 0x3, 0x32e528, 0xc74380, 0xc64e6c)
        /home/mbukowski/go/src/github.com/gesquive/fast-cli/fast/fast-api.go:15 +0x38
main.run(0x61a5e0, 0xc0c6e0, 0x0, 0x1)
        /home/mbukowski/go/src/github.com/gesquive/fast-cli/main.go:84 +0x64
github.com/spf13/cobra.(*Command).execute(0x61a5e0, 0xc0a038, 0x1, 0x1, 0x61a5e0, 0xc0a038)
        /home/mbukowski/go/src/github.com/spf13/cobra/command.go:854 +0x234
github.com/spf13/cobra.(*Command).ExecuteC(0x61a5e0, 0x25, 0xc64f80, 0x2)
        /home/mbukowski/go/src/github.com/spf13/cobra/command.go:958 +0x2d4
github.com/spf13/cobra.(*Command).Execute(...)
        /home/mbukowski/go/src/github.com/spf13/cobra/command.go:895
main.Execute(0xc10370, 0x10)
        /home/mbukowski/go/src/github.com/gesquive/fast-cli/main.go:47 +0x144
main.main()
        /home/mbukowski/go/src/github.com/gesquive/fast-cli/main.go:38 +0x11c
```

This happened both with `fast-cli` and `fast-cli -n`. Processing the error returned by `getPage()` I did get

```
$ ./fast-cli
Get "https://fast.com": x509: certificate signed by unknown authority
```

and identified that the CA certificates are missing. After installing `ca-bundle` on OpenWRT (`opkg install ca-bundle`) the error was resolved.